### PR TITLE
Qepm 1083 aws s 3 GitHub action implement multiline inputs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Upload, download, or list files/folders through Github Actions.
 - uses: pipedrive/aws-s3-github-action@master
   with:
     command: cp
-    source: ./local_file.txt
+    source: |
+      ./local_file.txt
+      ./local_file2.txt
     destination: s3://yourbucket/folder/local_file.txt
     aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR is created for supporting multiline string inputs for source directories
**Solution was tested by next:**

- [Single line input in SRE Smoke tests](https://github.com/pipedrive/sre-smoke-tests/actions/runs/6496303330/job/17643009661)
- [Multiline input in SRE Smoke tests](https://github.com/pipedrive/sre-smoke-tests/actions/runs/6496435398/job/17643401215)
- Locally with setting next values in bash env:
```
INPUT_SOURCE=Robert 3
Line 2
Line 3
INPUT_FLAGS=--recursive
COMMAND=cp
INPUT_DESTINATION=s3://random-destination
```

After running the entrypoint.sh script the output is next:

```
aws-s3-github-action git:(QEPM-1083-aws-s-3-github-action-implement-multiline-inputs-support) ./entrypoint.sh
v1.0.0
AWS Access Key Id was not found. Using configuration from previous step.
AWS Secret Access Key was not found. Using configuration from previous step.
AWS Session Token was not found. Using configuration from previous step.
Metadata service timeout was not found. Using configuration from previous step.
AWS region not found. Using configuration from previous step.
Command not set using cp
./entrypoint.sh: line 115: aws: command not found
aws s3 cp "Robert 3" s3://random-destination --recursive
./entrypoint.sh: line 122: aws: command not found
aws s3 cp "Line 2" s3://random-destination --recursive
./entrypoint.sh: line 122: aws: command not found
aws s3 cp "Line 3" s3://random-destination --recursive
./entrypoint.sh: line 122: aws: command not found
```
From the output it can be seen that the loop works & commands are formatted correctly