### PR TITLE
Revert "Qepm 1117 test artifacts integrate artifact storing flow into…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,27 +115,20 @@ main() {
   aws --version
 
   # Iterate over $INPUT_SOURCE multiline string and run aws s3 $COMMAND
-while IFS= read -r source; do
+  while IFS= read -r source; do
     if [ -n "$source" ]; then
-        if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]; then
-            if [ -n "$INPUT_FLAGS" ]; then
-                cmd="aws s3 $COMMAND \"$source\" $INPUT_DESTINATION $INPUT_FLAGS"
-                echo "Executing command: $cmd"
-                $cmd
-            else
-                cmd="aws s3 $COMMAND \"$source\" $INPUT_DESTINATION"
-                echo "Executing command: $cmd"
-                $cmd
-            fi
+        if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]
+        then
+            echo "aws s3 $COMMAND \"$source\" $INPUT_DESTINATION $INPUT_FLAGS"
+            aws s3 "$COMMAND" "$source" "$INPUT_DESTINATION" "$INPUT_FLAGS"
         else
-            cmd="aws s3 $COMMAND \"$source\" $INPUT_FLAGS"
-            echo "Executing command: $cmd"
-            $cmd
+            echo "aws s3 $COMMAND \"$source\" $INPUT_FLAGS"
+            aws s3 "$COMMAND" "$source" "$INPUT_FLAGS"
         fi
     else
         echo "Source is empty, skipping AWS S3 command."
     fi
-done <<< "$INPUT_SOURCE"
+  done <<< "$INPUT_SOURCE"
 }
 
 main


### PR DESCRIPTION
… important reusable workflows (#4)"

This reverts commit 995620efbeb130f42eb396bc05cc178059de9f5b.

reverting change that introduced issue for pushing allure reports to s3

**before the change:**
https://github.com/pipedrive/kb-renderer/actions/runs/6928723212/job/18845134919#step:14:104
no quotes around s3 path - command succeeds

**after the change:**
https://github.com/pipedrive/kb-renderer/actions/runs/6930776617/job/18851183929#step:14:104
quotes around s3 path - command fails due to incorrect argument type