### PR TITLE
Qepm 1117 test artifacts integrate artifact storing flow into important reusable workflows

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,20 +115,27 @@ main() {
   aws --version
 
   # Iterate over $INPUT_SOURCE multiline string and run aws s3 $COMMAND
-  while IFS= read -r source; do
+while IFS= read -r source; do
     if [ -n "$source" ]; then
-        if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]
-        then
-            echo "aws s3 $COMMAND \"$source\" $INPUT_DESTINATION $INPUT_FLAGS"
-            aws s3 "$COMMAND" "$source" "$INPUT_DESTINATION" "$INPUT_FLAGS"
+        if [ "$COMMAND" == "cp" ] || [ "$COMMAND" == "mv" ] || [ "$COMMAND" == "sync" ]; then
+            if [ -n "$INPUT_FLAGS" ]; then
+                cmd="aws s3 $COMMAND $source $INPUT_DESTINATION $INPUT_FLAGS"
+                echo "Executing command: $cmd"
+                $cmd
+            else
+                cmd="aws s3 $COMMAND $source $INPUT_DESTINATION"
+                echo "Executing command: $cmd"
+                $cmd
+            fi
         else
-            echo "aws s3 $COMMAND \"$source\" $INPUT_FLAGS"
-            aws s3 "$COMMAND" "$source" "$INPUT_FLAGS"
+            cmd="aws s3 $COMMAND $source $INPUT_FLAGS"
+            echo "Executing command: $cmd"
+            $cmd
         fi
     else
         echo "Source is empty, skipping AWS S3 command."
     fi
-  done <<< "$INPUT_SOURCE"
+done <<< "$INPUT_SOURCE"
 }
 
 main


### PR DESCRIPTION
This PR contains fix for removing string literals from source path

Tested the fix with newly created docker image, [cypress e2e workflow in gha_setup](https://github.com/pipedrive/gha-setup/compare/master...testing-aws-s3-github-action-fix)

- [SRE E2E Tests](https://github.com/pipedrive/sre-smoke-tests/actions/runs/6941026636), [S3 Artifacts](https://test-artifacts.pipedrive.tools/sre-smoke-tests/6941026636/) & [S3 Allure report ](https://allure.pipedrive.tools/sre-smoke-tests/e2e/6941026636/)